### PR TITLE
Switch SVM scripts to pandas CSV loading

### DIFF
--- a/svm_based_model/phase1_speech_vs_noise.py
+++ b/svm_based_model/phase1_speech_vs_noise.py
@@ -1,7 +1,6 @@
 from sklearn import svm
 import numpy as np
 from sklearn import mixture
-from numpy import genfromtxt
 import pandas as pd
 from sklearn.metrics import accuracy_score
 
@@ -15,8 +14,8 @@ def tetsting_unit( ):
     return tester
 
 
-x_train = genfromtxt('modified_data.csv', delimiter=',')
-y_train = genfromtxt('solution.csv',delimiter=',')
+x_train = pd.read_csv('modified_data.csv', header=None).values
+y_train = pd.read_csv('solution.csv', header=None).values.ravel()
 #print(x_train.shape, y_train.shape)
 clf = svm.SVC(kernel="linear")
 clf.fit(x_train, y_train)

--- a/svm_based_model/phase2_speech_vs_high_pitch.py
+++ b/svm_based_model/phase2_speech_vs_high_pitch.py
@@ -1,9 +1,7 @@
 from sklearn import svm
-import numpy as np
-from numpy import genfromtxt
 import pandas as pd
 from sklearn.metrics import accuracy_score
-x_train = genfromtxt('speech.csv',delimiter=',')
-y_train = genfromtxt('id_of_it.csv',delimiter=',')
+x_train = pd.read_csv('speech.csv', header=None).values
+y_train = pd.read_csv('id_of_it.csv', header=None).values.ravel()
 second_para = svm.SVC(C=20.0,gamma=0.00001)
 second_para.fit(x_train, y_train)

--- a/svm_based_model/phase3_shout vs Scream.py
+++ b/svm_based_model/phase3_shout vs Scream.py
@@ -1,10 +1,8 @@
 from sklearn import svm
-import numpy as np
-from numpy import genfromtxt
 import pandas as pd
 from sklearn.metrics import accuracy_score
 import pickle
-x_train = genfromtxt('pathlocation of csv',delimiter=',')
-y_train = genfromtxt('id_of_it  csv',delimiter=',')
+x_train = pd.read_csv('pathlocation of csv', header=None).values
+y_train = pd.read_csv('id_of_it  csv', header=None).values.ravel()
 third_para = svm.SVC(kernel='linear',C=20.0,gamma=0.00001)
 third_para.fit(x_train, y_train)


### PR DESCRIPTION
## Summary
- use `pandas.read_csv` instead of `numpy.genfromtxt` across SVM helper scripts

## Testing
- `python -m py_compile svm_based_model/phase1_speech_vs_noise.py svm_based_model/phase2_speech_vs_high_pitch.py 'svm_based_model/phase3_shout vs Scream.py'`


------
https://chatgpt.com/codex/tasks/task_e_6859ae85ccac83219b8b8bf411921884